### PR TITLE
fix(src): style option overrides the path option when recompiling

### DIFF
--- a/src.js
+++ b/src.js
@@ -59,14 +59,13 @@ class WebpackCdnPlugin {
   static _getCss(modules, url, prefix = empty, prod = false) {
     return modules.filter((p) => p.style).map((p) => {
       p.version = WebpackCdnPlugin._getVersion(p.name);
-      p.path = p.style;
 
       return prefix + url.replace(paramsRegex, (m, p1) => {
         if (prod && p.cdn && p1 === 'name') {
           return p.cdn;
         }
 
-        return p[p1];
+        return p[p1 === 'path' ? 'style' : p1];
       });
     });
   }


### PR DESCRIPTION
Thanks your plugin.

When webpack is recompiled, `style` has covered the `path`, resulting in the output of the label error.

```html
<link href="/node_modules/pkg/index.css" rel="stylesheet">

<script type="text/javascript" src="/node_modules/vue/dist/vue.runtime.js"></script>
```

Recompiled


```html
<script type="text/javascript" src="/node_modules/vue/dist/vue.runtime.js"></script>
<script type="text/javascript" src="/node_modules/pkg/index.css"></script>
```
