### PR TITLE
Mutiple cdn modules for mutiple pages app

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,49 @@ Please see the [example](example) folder for a basic working example.
 
 You can pass an object options to WebpackCdnPlugin. Allowed values are as follows:
 
-##### `modules`:`array`
+##### `modules`:`array` or `object`(for mutiple pages)
 
 The available options for each module, which is part of an array.
+If you want inject cdn for mutiple pages, you can config like this:
+
+```js
+plugins:[
+// ...otherConfig
+new HtmlWebpackPlugin({
+      title: 'title',
+      cdnModule: 'vue',
+      favicon: 'path/to/favicon',
+      template: 'path/to/template',
+      filename: 'filename',
+      // other config
+ }),
+ new HtmlWebpackPlugin({
+      title: 'title',
+      cdnModule: 'react',
+      favicon: 'path/to/favicon',
+      template: 'path/to/template',
+      filename: 'filename',
+      // other config
+  }),
+ new WebpackCdnPlugin({
+   modules: {
+      'vue': [
+        { name: 'vue', var: 'Vue', path: 'dist/vue.min.js' },
+      ],
+      'react': [
+        { name: 'react', var: 'React', path: `umd/react.${process.env.NODE_ENV}.min.js` },
+        { name: 'react-dom', var: 'ReactDOM', path: `umd/react-dom.${process.env.NODE_ENV}.min.js` },
+      ]
+    }
+ })
+]
+```
+
+The extra `html-webpack-plugin` option `cdnModule` corresponds to the configuration __key__ that you config inside the `webpack-cdn-plugin` modules
+- If you do not give `cdnModule` this value, the default is to take the first one
+- If you set `cdnModule = false`, it will not inject cdn
+
+More detail to see [#13](https://github.com/van-nguyen/webpack-cdn-plugin/pull/13)
 
 `name`:`string`
 

--- a/module.js
+++ b/module.js
@@ -52,9 +52,6 @@ class WebpackCdnPlugin {
     Reflect.ownKeys(this.modules).forEach((key) => {
       const mods = this.modules[key];
       mods.forEach((p) => {
-        // if (externals[p.name]) {
-        //   console.warn(`The key '${p.name}' of module ${key === DEFAULT_MODULE_KEY ? '' : `'${key}'`} already exists `); // eslint-disable-line
-        // }
         externals[p.name] = p.var || p.name;
       });
     });
@@ -70,35 +67,41 @@ class WebpackCdnPlugin {
     prefix = prefix || empty;
     prod = prod !== false;
 
-    return modules.filter(p => p.localStyle).map((p) => publicPath + p.localStyle).concat(modules.filter(p => p.style).map((p) => {
-      p.version = WebpackCdnPlugin.getVersion(p.name);
+    return modules
+      .filter(p => p.localStyle)
+      .map(p => publicPath + p.localStyle)
+      .concat(modules.filter(p => p.style).map((p) => {
+        p.version = WebpackCdnPlugin.getVersion(p.name);
 
-      return prefix + url.replace(paramsRegex, (m, p1) => {
-        if (prod && p.cdn && p1 === 'name') {
-          return p.cdn;
-        }
+        return prefix + url.replace(paramsRegex, (m, p1) => {
+          if (prod && p.cdn && p1 === 'name') {
+            return p.cdn;
+          }
 
-        return p[p1 === 'path' ? 'style' : p1];
-      });
-    }));
+          return p[p1 === 'path' ? 'style' : p1];
+        });
+      }));
   }
 
   static _getJs(modules, url, prefix, prod, publicPath) {
     prefix = prefix || empty;
     prod = prod !== false;
 
-    return modules.filter(p => p.localScript).map((p) => publicPath + p.localScript).concat(modules.filter(p => !p.cssOnly).map((p) => {
-      p.version = WebpackCdnPlugin.getVersion(p.name);
-      p.path = p.path || require.resolve(p.name).match(/[\\/]node_modules[\\/].+?[\\/](.*)/)[1].replace(/\\/g, '/');
+    return modules
+      .filter(p => p.localScript)
+      .map(p => publicPath + p.localScript)
+      .concat(modules.filter(p => !p.cssOnly).map((p) => {
+        p.version = WebpackCdnPlugin.getVersion(p.name);
+        p.path = p.path || require.resolve(p.name).match(/[\\/]node_modules[\\/].+?[\\/](.*)/)[1].replace(/\\/g, '/');
 
-      return prefix + url.replace(paramsRegex, (m, p1) => {
-        if (prod && p.cdn && p1 === 'name') {
-          return p.cdn;
-        }
+        return prefix + url.replace(paramsRegex, (m, p1) => {
+          if (prod && p.cdn && p1 === 'name') {
+            return p.cdn;
+          }
 
-        return p[p1];
-      });
-    }));
+          return p[p1];
+        });
+      }));
   }
 }
 

--- a/module.js
+++ b/module.js
@@ -39,8 +39,10 @@ class WebpackCdnPlugin {
         const moduleId = data.plugin.options.cdnModule;
         if (moduleId !== false) {
           const modules = this.modules[moduleId || Reflect.ownKeys(this.modules)[0]];
-          data.assets.js = WebpackCdnPlugin._getJs(modules, ...getArgs).concat(data.assets.js);
-          data.assets.css = WebpackCdnPlugin._getCss(modules, ...getArgs).concat(data.assets.css);
+          if (modules) {
+            data.assets.js = WebpackCdnPlugin._getJs(modules, ...getArgs).concat(data.assets.js);
+            data.assets.css = WebpackCdnPlugin._getCss(modules, ...getArgs).concat(data.assets.css);
+          }
         }
         callback(null, data);
       });
@@ -50,9 +52,9 @@ class WebpackCdnPlugin {
     Reflect.ownKeys(this.modules).forEach((key) => {
       const mods = this.modules[key];
       mods.forEach((p) => {
-        if (externals[p.name]) {
-          console.warn(`The key '${p.name}' of module ${key === DEFAULT_MODULE_KEY ? '' : `'${key}'`} already exists `); // eslint-disable-line
-        }
+        // if (externals[p.name]) {
+        //   console.warn(`The key '${p.name}' of module ${key === DEFAULT_MODULE_KEY ? '' : `'${key}'`} already exists `); // eslint-disable-line
+        // }
         externals[p.name] = p.var || p.name;
       });
     });

--- a/spec/webpack.spec.js
+++ b/spec/webpack.spec.js
@@ -18,7 +18,7 @@ const versions = {
   jasmineSpecReporter: WebpackCdnPlugin.getVersion('jasmine-spec-reporter'),
   nyc: WebpackCdnPlugin.getVersion('nyc'),
   jasmineCore: WebpackCdnPlugin.getVersion('jasmine-core'),
-  nopt: WebpackCdnPlugin.getVersion('nopt'),
+  archy: WebpackCdnPlugin.getVersion('archy'),
 };
 
 const fs = new webpack.MemoryOutputFileSystem();
@@ -101,7 +101,7 @@ function getConfig({
           localStyle: 'local.css',
           localScript: 'local.js',
         },
-        { name: 'nopt', cdn: 'nopt', style: 'style.css' },
+        { name: 'archy', cdn: 'archy', style: 'style.css' },
       ],
     };
   }
@@ -204,7 +204,7 @@ describe('Webpack Integration', () => {
         expect(cssAssets2).toEqual([
           '/assets/local.css',
           `//unpkg.com/nyc@${versions.nyc}/style.css`,
-          `//unpkg.com/nopt@${versions.nopt}/style.css`,
+          `//unpkg.com/archy@${versions.archy}/style.css`,
         ]);
       });
 
@@ -220,7 +220,7 @@ describe('Webpack Integration', () => {
           '/assets/local.js',
           `//unpkg.com/jasmine-core@${versions.jasmineCore}/index.js`,
           `//unpkg.com/nyc@${versions.nyc}/index.js`,
-          `//unpkg.com/nopt@${versions.nopt}/lib/nopt.js`,
+          `//unpkg.com/archy@${versions.archy}/index.js`,
           '/assets/app.js',
         ]);
       });
@@ -305,7 +305,7 @@ describe('Webpack Integration', () => {
       });
       it('should output the right assets (css)', () => {
         expect(cssAssets).toEqual(['/local.css', '/nyc/style.css', '/jasmine/style.css']);
-        expect(cssAssets2).toEqual(['/local.css', '/nyc/style.css', '/nopt/style.css']);
+        expect(cssAssets2).toEqual(['/local.css', '/nyc/style.css', '/archy/style.css']);
       });
 
       it('should output the right assets (js)', () => {
@@ -320,7 +320,7 @@ describe('Webpack Integration', () => {
           '/local.js',
           '/jasmine-core/index.js',
           '/nyc/index.js',
-          '/nopt/lib/nopt.js',
+          '/archy/index.js',
           '/app.js',
         ]);
       });


### PR DESCRIPTION
webpack.config.js
```js
plugins:[
// ...otherConfig
new HtmlWebpackPlugin({
      title: config.title,
      favicon: path.resolve(__dirname, './favicon.png'),
      template: path.resolve(__dirname, './index.html'),
      filename: './generator/index.html',
      chunks: ['generator', 'vendor']
 }),
 new HtmlWebpackPlugin({
      title: config.title,
      // This value corresponds to the configuration key inside the modules
      cdnModule: 'react', 
      favicon: path.resolve(__dirname, './favicon.png'),
      template: path.resolve(__dirname, './index.html'),
      filename: './admin/index.html',
      chunks: ['admin', 'vendor']
  }),
 new WebpackCdnPlugin({
   modules: {
      'vue': [
        { name: 'vue', var: 'Vue', path: 'dist/vue.min.js' },
      ],
      'react': [
        { name: 'react', var: 'React', path: `umd/react.${process.env.NODE_ENV}.min.js` },
        { name: 'react-dom', var: 'ReactDOM', path: `umd/react-dom.${process.env.NODE_ENV}.min.js` },
      ]
    }
 })
]
```
- If you do not give `cdnModule` this value, the default is to take the first one
- If you set `cdnModule = false`, it will not inject cdn

Do not worry, it is still compatible with the previous configuration 😀