### PR TITLE
feat: optimize unused modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,10 @@ Similar to `prodUrl`, this option overrides the default template url for when `p
 
 Prefixes the assets with this string, if none is provided it will fallback to the one set globally in `webpack.options.output.publicPath`, note that this is always empty when prod is `true` so that it makes use of the CDN location because it is a remote resource.
 
+##### `optimize`:`boolean` | `false`
+
+Set to `true` to ignore every module not actually required in your bundle. 
+
 ### Contribution
 
 This is a pretty simple plugin and caters mostly for my needs. However, I have made it as flexible and customizable as possible.

--- a/spec/webpack.spec.js
+++ b/spec/webpack.spec.js
@@ -62,6 +62,7 @@ function getConfig({
   prodUrl,
   multiple,
   multipleFiles,
+  optimize,
 }) {
   const output = {
     path: path.join(__dirname, 'dist/assets'),
@@ -129,6 +130,7 @@ function getConfig({
     modules,
     prod,
     prodUrl,
+    optimize,
   };
 
   if (publicPath) {
@@ -382,20 +384,39 @@ describe('Webpack Integration', () => {
 
       it('should output the right assets (css)', () => {
         expect(cssAssets).toEqual([
-            '/jasmine/style1.css',
-            '/jasmine/style2.css',
-            '/archy/style1.css',
-            '/archy/style2.css',
+          '/jasmine/style1.css',
+          '/jasmine/style2.css',
+          '/archy/style1.css',
+          '/archy/style2.css',
         ]);
       });
 
       it('should output the right assets (js)', () => {
         expect(jsAssets).toEqual([
-            '/jasmine/index1.js',
-            '/jasmine/index2.js',
-            '/archy/index1.js',
-            '/archy/index2.js',
-            '/app.js'
+          '/jasmine/index1.js',
+          '/jasmine/index2.js',
+          '/archy/index1.js',
+          '/archy/index2.js',
+          '/app.js'
+        ]);
+      });
+    });
+
+    describe('With `optimize`', () => {
+      beforeAll((done) => {
+        runWebpack(done, getConfig({ prod: false, publicPath: null, publicPath2: null, optimize: true }));
+      });
+
+      it('should output the right assets (css)', () => {
+        expect(cssAssets).toEqual([
+            '/jasmine/style.css',
+        ]);
+      });
+
+      it('should output the right assets (js)', () => {
+        expect(jsAssets).toEqual([
+            '/jasmine/lib/jasmine.js',
+            '/app.js',
         ]);
       });
     });


### PR DESCRIPTION
This new "optimize" option will ignore any configured module if not actually used in the bundle.

Use case : I have a modular multi NPM module architecture for my company, the "build" module contains the complete configuration for building the applications using optional modules like "editor", "calendar", etc.
If an application does not use the "calendar" plugin, the dependencies will still be loaded from the CDN because they are configured in the "build" module.

See this like a tree-shaking :-)

PS: there will be merge conflicts with my other PR, I will rebase either one or the other when needed.