### PR TITLE
fix: always use https with unpkg

### DIFF
--- a/module.js
+++ b/module.js
@@ -9,7 +9,7 @@ const DEFAULT_MODULE_KEY = 'defaultCdnModuleKey____';
 class WebpackCdnPlugin {
   constructor({
     modules, prod,
-    prodUrl = '//unpkg.com/:name@:version/:path',
+    prodUrl = 'https://unpkg.com/:name@:version/:path',
     devUrl = ':name/:path', publicPath,
   }) {
     this.modules = Array.isArray(modules) ? { [DEFAULT_MODULE_KEY]: modules } : modules;

--- a/spec/webpack.spec.js
+++ b/spec/webpack.spec.js
@@ -139,17 +139,17 @@ describe('Webpack Integration', () => {
       it('should output the right assets (css)', () => {
         expect(cssAssets).toEqual([
           '/assets/local.css',
-          `//unpkg.com/nyc@${versions.nyc}/style.css`,
-          `//unpkg.com/jasmine2@${versions.jasmine}/style.css`,
+          `https://unpkg.com/nyc@${versions.nyc}/style.css`,
+          `https://unpkg.com/jasmine2@${versions.jasmine}/style.css`,
         ]);
       });
 
       it('should output the right assets (js)', () => {
         expect(jsAssets).toEqual([
           '/assets/local.js',
-          `//unpkg.com/jasmine-spec-reporter@${versions.jasmineSpecReporter}/index.js`,
-          `//unpkg.com/nyc@${versions.nyc}/index.js`,
-          `//unpkg.com/jasmine2@${versions.jasmine}/lib/jasmine.js`,
+          `https://unpkg.com/jasmine-spec-reporter@${versions.jasmineSpecReporter}/index.js`,
+          `https://unpkg.com/nyc@${versions.nyc}/index.js`,
+          `https://unpkg.com/jasmine2@${versions.jasmine}/lib/jasmine.js`,
           '/assets/app.js',
         ]);
       });
@@ -199,29 +199,29 @@ describe('Webpack Integration', () => {
       it('should output the right assets (css)', () => {
         expect(cssAssets).toEqual([
           '/assets/local.css',
-          `//unpkg.com/nyc@${versions.nyc}/style.css`,
-          `//unpkg.com/jasmine2@${versions.jasmine}/style.css`,
+          `https://unpkg.com/nyc@${versions.nyc}/style.css`,
+          `https://unpkg.com/jasmine2@${versions.jasmine}/style.css`,
         ]);
         expect(cssAssets2).toEqual([
           '/assets/local.css',
-          `//unpkg.com/nyc@${versions.nyc}/style.css`,
-          `//unpkg.com/archy@${versions.archy}/style.css`,
+          `https://unpkg.com/nyc@${versions.nyc}/style.css`,
+          `https://unpkg.com/archy@${versions.archy}/style.css`,
         ]);
       });
 
       it('should output the right assets (js)', () => {
         expect(jsAssets).toEqual([
           '/assets/local.js',
-          `//unpkg.com/jasmine-spec-reporter@${versions.jasmineSpecReporter}/index.js`,
-          `//unpkg.com/nyc@${versions.nyc}/index.js`,
-          `//unpkg.com/jasmine2@${versions.jasmine}/lib/jasmine.js`,
+          `https://unpkg.com/jasmine-spec-reporter@${versions.jasmineSpecReporter}/index.js`,
+          `https://unpkg.com/nyc@${versions.nyc}/index.js`,
+          `https://unpkg.com/jasmine2@${versions.jasmine}/lib/jasmine.js`,
           '/assets/app.js',
         ]);
         expect(jsAssets2).toEqual([
           '/assets/local.js',
-          `//unpkg.com/jasmine-core@${versions.jasmineCore}/index.js`,
-          `//unpkg.com/nyc@${versions.nyc}/index.js`,
-          `//unpkg.com/archy@${versions.archy}/index.js`,
+          `https://unpkg.com/jasmine-core@${versions.jasmineCore}/index.js`,
+          `https://unpkg.com/nyc@${versions.nyc}/index.js`,
+          `https://unpkg.com/archy@${versions.archy}/index.js`,
           '/assets/app.js',
         ]);
       });


### PR DESCRIPTION
I don't see why you wouldn't use https with unpkg.
When I hit localhost (non-https), I get "Refused to load the script" error.