### PR TITLE
wrapping getVersion in try/catch in case something defined in config …

### DIFF
--- a/module.js
+++ b/module.js
@@ -73,7 +73,9 @@ class WebpackCdnPlugin {
    * Returns the version of a package
    */
   static getVersion(name) {
-    return require(path.join(WebpackCdnPlugin.node_modules, name, packageJson)).version;
+    try {
+      return require(path.join(WebpackCdnPlugin.node_modules, name, packageJson)).version;
+    } catch(e) {}
   }
 
   /**


### PR DESCRIPTION
…doesnt exist locally

If the CDN config object contains any dependencies that are not installed locally, webpack will fail on trying to require it. The use-case is that if there is a shared CDN config object that can contain all possible dependencies and users have the ability to include the ones they need, we wouldn't the build to fail.