### PR TITLE
feat: allow module specific CDN URL configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,14 @@ Useful when you wanted to use your own build version of the library for js files
 
 Useful when you wanted to use your own build version of the library for css files
 
+`prodUrl`:`string` (option)
+
+Overrides the global prodUrl, allowing you to specify the CDN location for a specific module
+
+`devUrl`:`string` (option)
+
+Overrides the global devUrl, allowing you to specify the location for a specific module
+
 
 ##### `prod`:`boolean` | `true`
 

--- a/module.js
+++ b/module.js
@@ -181,8 +181,9 @@ class WebpackCdnPlugin {
 
     modules.filter(p => p[pathsKey].length > 0)
       .forEach(p => {
+        const moduleSpecificUrl = (prod ? p.prodUrl : p.devUrl)
         p[pathsKey].forEach(s => files.push(
-          prefix + url.replace(paramsRegex, (m, p1) => {
+          prefix + (moduleSpecificUrl || url).replace(paramsRegex, (m, p1) => {
             if (prod && p.cdn && p1 === 'name') {
               return p.cdn;
             }

--- a/spec/webpack.spec.js
+++ b/spec/webpack.spec.js
@@ -70,6 +70,8 @@ function getConfig({
   publicPath = '/node_modules',
   publicPath2 = '/assets',
   prodUrl,
+  moduleProdUrl,
+  moduleDevUrl,
   multiple,
   multipleFiles,
   optimize,
@@ -94,6 +96,12 @@ function getConfig({
     },
     { name: 'jasmine', cdn: 'jasmine2', style: 'style.css' },
   ];
+  if (moduleProdUrl) {
+    modules[2].prodUrl = moduleProdUrl;
+  }
+  if (moduleDevUrl) {
+    modules[2].devUrl = moduleDevUrl;
+  }
   if (multiple) {
     modules = {
       module1: modules,
@@ -215,6 +223,39 @@ describe('Webpack Integration', () => {
           }/index.js`,
           `//cdnjs.cloudflare.com/ajax/libs/nyc/${versions.nyc}/index.js`,
           `//cdnjs.cloudflare.com/ajax/libs/jasmine2/${versions.jasmine}/lib/jasmine.js`,
+          '/assets/app.js',
+        ]);
+      });
+    });
+
+    describe('When module `prodUrl` is set', () => {
+      beforeAll((done) => {
+        runWebpack(
+          done,
+          getConfig({
+            prod: true,
+            prodUrl: '//cdnjs.cloudflare.com/ajax/libs/:name/:version/:path',
+            moduleProdUrl: '//cdn.jsdelivr.net/npm/:name@:version/:path',
+          }),
+        );
+      });
+
+      it('should output the right assets (css)', () => {
+        expect(cssAssets).toEqual([
+          '/assets/local.css',
+          `//cdnjs.cloudflare.com/ajax/libs/nyc/${versions.nyc}/style.css`,
+          `//cdn.jsdelivr.net/npm/jasmine2@${versions.jasmine}/style.css`,
+        ]);
+      });
+
+      it('should output the right assets (js)', () => {
+        expect(jsAssets).toEqual([
+          '/assets/local.js',
+          `//cdnjs.cloudflare.com/ajax/libs/jasmine-spec-reporter/${
+            versions.jasmineSpecReporter
+          }/index.js`,
+          `//cdnjs.cloudflare.com/ajax/libs/nyc/${versions.nyc}/index.js`,
+          `//cdn.jsdelivr.net/npm/jasmine2@${versions.jasmine}/lib/jasmine.js`,
           '/assets/app.js',
         ]);
       });
@@ -372,6 +413,33 @@ describe('Webpack Integration', () => {
           '/node_modules/jasmine-spec-reporter/index.js',
           '/node_modules/nyc/index.js',
           '/node_modules/jasmine/lib/jasmine.js',
+          '/assets/app.js',
+        ]);
+      });
+    });
+
+    describe('When module `devUrl` is set', () => {
+      beforeAll((done) => {
+        runWebpack(done, getConfig({
+          prod: false,
+          moduleDevUrl: ":name/dist/:path",
+        }));
+      });
+
+      it('should output the right assets (css)', () => {
+        expect(cssAssets).toEqual([
+          '/assets/local.css',
+          '/node_modules/nyc/style.css',
+          '/node_modules/jasmine/dist/style.css',
+        ]);
+      });
+
+      it('should output the right assets (js)', () => {
+        expect(jsAssets).toEqual([
+          '/assets/local.js',
+          '/node_modules/jasmine-spec-reporter/index.js',
+          '/node_modules/nyc/index.js',
+          '/node_modules/jasmine/dist/lib/jasmine.js',
           '/assets/app.js',
         ]);
       });


### PR DESCRIPTION
Sometimes it's necessary to fetch some js files from another location different from the global configuration (e.g. if you're hosting your website with firebase it's preferred to fetch the firebase files from "/__/firebase/5.5.7/firebase.js") This pull request allow users to specify a module-wide URL to override the global URL.