### PR TITLE
Custom injected cdn file location

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,8 +182,8 @@ new HtmlWebpackPlugin({
  }),
  new WebpackCdnPlugin({
    modules: [
-      { name: 'react', var: 'React', path: `dist//react.min.js` },
-      { name: 'react-dom', var: 'ReactDOM', path: `umd/react-dom.min.js` },
+      { name: 'react', var: 'React', path: `dist/react.min.js` },
+      { name: 'react-dom', var: 'ReactDOM', path: `dist/react-dom.min.js` },
     ]
  })
 ]

--- a/README.md
+++ b/README.md
@@ -168,6 +168,34 @@ The extra `html-webpack-plugin` option `cdnModule` corresponds to the configurat
 
 More detail to see [#13](https://github.com/van-nguyen/webpack-cdn-plugin/pull/13)
 
+The extra `html-webpack-plugin` option `assetsCdnName`:
+```js
+plugins:[
+// ...otherConfig
+new HtmlWebpackPlugin({
+      title: 'title',
+      assetsCdnName: 'cdn',
+      favicon: 'path/to/favicon',
+      template: 'path/to/template',
+      filename: 'filename',
+      // other config
+ }),
+ new WebpackCdnPlugin({
+   modules: [
+      { name: 'react', var: 'React', path: `dist//react.min.js` },
+      { name: 'react-dom', var: 'ReactDOM', path: `umd/react-dom.min.js` },
+    ]
+ })
+]
+```
+
+```html
+<% htmlWebpackPlugin.files.cdn.js.forEach(function(link){ %>
+    <script src="<%= link %>"></script>
+<% }) %>
+```
+Customize the injected location by specifying the injected key `html-webpack-plugin` option `assetsCdnName` to get the injected cdn link.
+
 `name`:`string`
 
 The name of the module you want to externalize

--- a/module.js
+++ b/module.js
@@ -45,6 +45,12 @@ class WebpackCdnPlugin {
         'WebpackCdnPlugin',
         (data, callback) => {
           const moduleId = data.plugin.options.cdnModule;
+          const assetsCdnName = data.plugin.options.assetsCdnName;
+
+          if(assetsCdnName) {
+            data.assets[assetsCdnName] =  data.assets[assetsCdnName] || {js:[], css:[]};
+          }
+
           if (moduleId !== false) {
             let modules = this.modules[moduleId || Reflect.ownKeys(this.modules)[0]];
             if (modules) {
@@ -54,10 +60,15 @@ class WebpackCdnPlugin {
               }
 
               WebpackCdnPlugin._cleanModules(modules);
-              data.assets.js = WebpackCdnPlugin._getJs(modules, ...getArgs).concat(data.assets.js);
-              data.assets.css = WebpackCdnPlugin._getCss(modules, ...getArgs).concat(
-                data.assets.css,
-              );
+              if(assetsCdnName) {
+                data.assets[assetsCdnName].js = WebpackCdnPlugin._getJs(modules, ...getArgs).concat(data.assets[assetsCdnName].js);
+                data.assets[assetsCdnName].css = WebpackCdnPlugin._getCss(modules, ...getArgs).concat(data.assets[assetsCdnName].css);
+              } else {
+                data.assets.js = WebpackCdnPlugin._getJs(modules, ...getArgs).concat(data.assets.js);
+                data.assets.css = WebpackCdnPlugin._getCss(modules, ...getArgs).concat(
+                  data.assets.css,
+                );
+              }
             }
           }
           callback(null, data);


### PR DESCRIPTION
Add the extra `html-webpack-plugin` option `assetsCdnName`:
```js
plugins:[
// ...otherConfig
new HtmlWebpackPlugin({
      title: 'title',
      assetsCdnName: 'cdn',
      favicon: 'path/to/favicon',
      template: 'path/to/template',
      filename: 'filename',
      // other config
 }),
 new WebpackCdnPlugin({
   modules: [
      { name: 'react', var: 'React', path: `dist/react.min.js` },
      { name: 'react-dom', var: 'ReactDOM', path: `dist/react-dom.min.js` },
    ]
 })
]
```

```html
<% htmlWebpackPlugin.files.cdn.js.forEach(function(link){ %>
    <script src="<%= link %>"></script>
<% }) %>
```
So I can put the cdn link at the top of all the files.